### PR TITLE
Omit plugin name only when vl.Plugin == vl.Type

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ var (
 // newName converts one data source of a value list to a string representation.
 func newName(vl api.ValueList, index int) string {
 	var name string
-	if vl.Plugin == vl.Type || strings.HasPrefix(vl.Type, vl.Plugin+"_") {
+	if vl.Plugin == vl.Type {
 		name = "collectd_" + vl.Type
 	} else {
 		name = "collectd_" + vl.Plugin + "_" + vl.Type


### PR DESCRIPTION
Attempt to fix #22.

Since there's no way to check whether two metrics (with name conflicts) have the same type or not, here I suggest that we avoid "over-process" when generating metric names.

The side (negative) effect is, we would see metric named like this:

```
collectd_ping_ping_droprate
collectd_df_df_complex
collectd_disk_disk_merged_write
collectd_nginx_nginx_connections
```