### PR TITLE
Fix DNS plugin test

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -42,7 +42,7 @@ func TestNewName(t *testing.T) {
 			},
 			DSNames: []string{"value"},
 			Values:  []api.Value{api.Derive(0)},
-		}, 0, "collectd_dns_qtype"},
+		}, 0, "collectd_dns_dns_qtype"},
 		{api.ValueList{
 			Identifier: api.Identifier{
 				Plugin: "df",


### PR DESCRIPTION
Since the plugin name is "dns" and the type is "dns_qtype" this seems like the correct behaviour (and makes the test pass).