### PR TITLE
Add support for tuning a receive buffer of the UDP socket

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -41,6 +42,7 @@ var (
 	showVersion      = flag.Bool("version", false, "Print version information.")
 	listenAddress    = flag.String("web.listen-address", ":9103", "Address on which to expose metrics and web interface.")
 	collectdAddress  = flag.String("collectd.listen-address", "", "Network address on which to accept collectd binary network packets, e.g. \":25826\".")
+	collectdBuffer   = flag.Int("collectd.udp-buffer", 0, "Size of the receive buffer of the socket used by collectd binary protocol receiver.")
 	collectdAuth     = flag.String("collectd.auth-file", "", "File mapping user names to pre-shared keys (passwords).")
 	collectdSecurity = flag.String("collectd.security-level", "None", "Minimum required security level for accepted packets. Must be one of \"None\", \"Sign\" and \"Encrypt\".")
 	metricsPath      = flag.String("web.telemetry-path", "/metrics", "Path under which to expose Prometheus metrics.")
@@ -246,6 +248,25 @@ func startCollectdServer(ctx context.Context, w api.Writer) {
 		srv.SecurityLevel = network.Encrypt
 	default:
 		log.Fatalf("Unknown security level %q. Must be one of \"None\", \"Sign\" and \"Encrypt\".", *collectdSecurity)
+	}
+
+	laddr, err := net.ResolveUDPAddr("udp", *collectdAddress)
+	if err != nil {
+		log.Fatalf("Failed to resolve binary protocol listening UDP address %q: %v", *collectdAddress, err)
+	}
+
+	if laddr.IP != nil && laddr.IP.IsMulticast() {
+		srv.Conn, err = net.ListenMulticastUDP("udp", nil, laddr)
+	} else {
+		srv.Conn, err = net.ListenUDP("udp", laddr)
+	}
+	if err != nil {
+		log.Fatalf("Failed to create a socket for a binary protocol server: %v", err)
+	}
+	if *collectdBuffer >= 0 {
+		if err = srv.Conn.SetReadBuffer(*collectdBuffer); err != nil {
+			log.Fatalf("Failed to adjust a read buffer of the socket: %v", err)
+		}
 	}
 
 	go func() {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -5,20 +5,20 @@
 		{
 			"checksumSHA1": "t/SEkGSl0/OEKHNyUpsYrwcsfus=",
 			"path": "collectd.org/api",
-			"revision": "1ec72cad780eca2b842aa2c30bbc634e415645f4",
-			"revisionTime": "2016-08-25T11:10:03Z"
+			"revision": "c19ea48bfbf6f5aaa23a06f5cea768b7cfdd8fb5",
+			"revisionTime": "2016-09-12T13:33:33Z"
 		},
 		{
 			"checksumSHA1": "VTTIMq9P+UTmF8NIainR7EbobM0=",
 			"path": "collectd.org/cdtime",
-			"revision": "1ec72cad780eca2b842aa2c30bbc634e415645f4",
-			"revisionTime": "2016-08-25T11:10:03Z"
+			"revision": "c19ea48bfbf6f5aaa23a06f5cea768b7cfdd8fb5",
+			"revisionTime": "2016-09-12T13:33:33Z"
 		},
 		{
-			"checksumSHA1": "5+WAbhw2TMrAuqZA4JHz4iTeLHc=",
+			"checksumSHA1": "nYaRVCWraVHXiyXVa93rKs9aw0o=",
 			"path": "collectd.org/network",
-			"revision": "1ec72cad780eca2b842aa2c30bbc634e415645f4",
-			"revisionTime": "2016-08-25T11:10:03Z"
+			"revision": "c19ea48bfbf6f5aaa23a06f5cea768b7cfdd8fb5",
+			"revisionTime": "2016-09-12T13:33:33Z"
 		},
 		{
 			"checksumSHA1": "SdEcxwaW92m0H3pao3BPj2ZpvaU=",


### PR DESCRIPTION
In case of larger collectd traffic there is a need to increase a receive buffer of the UDP socket to avoid drops. Increasing defaults in OS is not often what you really want to do, as it changes default for all sockets in the system.

With go-collectd you can create your own socket, apply all needed options and pass it to the Server (https://github.com/collectd/go-collectd/issues/22).

Probably there should be defer to close the socket as well somewhere, but I'm not really sure how it should be used with goroutines.