### PR TITLE
Append the "_total" suffix to api.Derive metrics, too.

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func newName(vl api.ValueList, index int) string {
 		name += "_" + dsname
 	}
 	switch vl.Values[index].(type) {
-	case api.Counter:
+	case api.Counter, api.Derive:
 		name += "_total"
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -34,7 +34,7 @@ func TestNewName(t *testing.T) {
 			},
 			DSNames: []string{"value"},
 			Values:  []api.Value{api.Derive(0)},
-		}, 0, "collectd_cpu"},
+		}, 0, "collectd_cpu_total"},
 		{api.ValueList{
 			Identifier: api.Identifier{
 				Plugin: "dns",
@@ -42,7 +42,7 @@ func TestNewName(t *testing.T) {
 			},
 			DSNames: []string{"value"},
 			Values:  []api.Value{api.Derive(0)},
-		}, 0, "collectd_dns_dns_qtype"},
+		}, 0, "collectd_dns_dns_qtype_total"},
 		{api.ValueList{
 			Identifier: api.Identifier{
 				Plugin: "df",


### PR DESCRIPTION
Both, `api.Counter` and `api.Derive`, are cumulative counters.

Fixes: collectd/collectd#2079