### PR TITLE
Protect against invalid metric names

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -53,6 +54,7 @@ var (
 			Help: "Unix timestamp of the last received collectd metrics push in seconds.",
 		},
 	)
+	metric_name_re = regexp.MustCompile("[^a-zA-Z0-9_:]")
 )
 
 // newName converts one data source of a value list to a string representation.
@@ -71,7 +73,7 @@ func newName(vl api.ValueList, index int) string {
 		name += "_total"
 	}
 
-	return name
+	return metric_name_re.ReplaceAllString(name, "_")
 }
 
 // newLabels converts the plugin and type instance of vl to a set of prometheus.Labels.

--- a/main_test.go
+++ b/main_test.go
@@ -83,6 +83,14 @@ func TestNewName(t *testing.T) {
 			DSNames: []string{"rx", "tx"},
 			Values:  []api.Value{api.Counter(0), api.Counter(1)},
 		}, 1, "collectd_interface_if_octets_tx_total"},
+		{api.ValueList{
+			Identifier: api.Identifier{
+				Plugin: "docker",
+				Type:   "cpu.percent",
+			},
+			DSNames: []string{"value"},
+			Values:  []api.Value{api.Gauge(0)},
+		}, 0, "collectd_docker_cpu_percent"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
This change prevents the collectd exporter to expose invalid metric
names. The offending characters are replaced by '_'.

Fixes #46.

I was wondering whether we needed a configuration flag to choose between strict mode (skip invalid metrics) and relax mode (this patch) but I assumed that most people won't be able/willing to fix their collectd plugins and would prefer to get the metrics, even a bit munged.