### PR TITLE
fix: skip duplicate data source names in ValueList

### DIFF
--- a/main.go
+++ b/main.go
@@ -212,7 +212,7 @@ func (c collectdCollector) Collect(ch chan<- prometheus.Metric) {
 
 		for i := range vl.Values {
 			dsName := vl.DSName(i)
-			if _, ok := dsNameSeen[dsName]; !ok {
+			if _, seen := dsNameSeen[dsName]; !seen {
 				dsNameSeen[dsName] = true
 
 				m, err := newMetric(vl, i)
@@ -222,6 +222,8 @@ func (c collectdCollector) Collect(ch chan<- prometheus.Metric) {
 				}
 
 				ch <- m
+			} else {
+				level.Warn(c.logger).Log("msg", "Ignoring metric for already seen data source name", "name", dsName)
 			}
 		}
 	}


### PR DESCRIPTION
The DSName of each Value in a ValueList is [appended to the metric name](https://github.com/prometheus/collectd_exporter/blob/b3be8420bc1031e1c74264121f35a866869b4be3/main.go#L73). Data source names might appear multiple times. As these are not part of the identifier string, however, and therefore not part of the [map key](https://github.com/prometheus/collectd_exporter/blob/b3be8420bc1031e1c74264121f35a866869b4be3/main.go#L172), this might lead to duplicate metric names and the following error from prometheus: `... was collected before with the same name and label values`.

This PR adds a condition to the `Collect` function which skips metrics with a DSName that has already been processed.

fixes #68