### PR TITLE
Protect against invalid metric labels

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,15 +86,15 @@ func newName(vl api.ValueList, index int) string {
 // newLabels converts the plugin and type instance of vl to a set of prometheus.Labels.
 func newLabels(vl api.ValueList) prometheus.Labels {
 	labels := prometheus.Labels{}
+	key := metric_name_re.ReplaceAllString(vl.Plugin, "_")
 	if vl.PluginInstance != "" {
-		labels[vl.Plugin] = vl.PluginInstance
+		labels[key] = metric_name_re.ReplaceAllString(vl.PluginInstance, "_")
 	}
 	if vl.TypeInstance != "" {
-		if vl.PluginInstance == "" {
-			labels[vl.Plugin] = vl.TypeInstance
-		} else {
-			labels["type"] = vl.TypeInstance
+		if vl.PluginInstance != "" {
+			key = "type"
 		}
+		labels[key] = metric_name_re.ReplaceAllString(vl.TypeInstance, "_")
 	}
 	labels["instance"] = vl.Host
 


### PR DESCRIPTION
The released code already fixes the metric names but the same fix needs to be applied to labels for this to work. e.g. the `.` from the collectd labels needs to be removed as well.
@juliusv Please review and let me know your comments.