### PR TITLE
Remove ppc64le docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 all::
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64 armv7 arm64 ppc64le s390x
+DOCKER_ARCHS ?= amd64 armv7 arm64 s390x
 
 include Makefile.common
 


### PR DESCRIPTION
For unknown reasons this architecture refuses to build a Docker image. There is not currently time to maintain this. Remove to fix the publishing pipeline.