### PR TITLE
build: add distroless image variant

### DIFF
--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,0 +1,23 @@
+ARG DISTROLESS_ARCH="amd64"
+
+# Use DISTROLESS_ARCH for base image selection (handles armv7->arm mapping).
+FROM gcr.io/distroless/static-debian13:nonroot-${DISTROLESS_ARCH}
+# Base image sets USER to 65532:65532 (nonroot user).
+
+ARG ARCH="amd64"
+ARG OS="linux"
+
+LABEL org.opencontainers.image.authors="The Prometheus Authors"
+LABEL org.opencontainers.image.vendor="Prometheus"
+LABEL org.opencontainers.image.title="collectd_exporter"
+LABEL org.opencontainers.image.description="A server that accepts collectd stats via HTTP POST and exports them via HTTP for Prometheus consumption"
+LABEL org.opencontainers.image.source="https://github.com/prometheus/collectd_exporter"
+LABEL org.opencontainers.image.url="https://github.com/prometheus/collectd_exporter"
+LABEL org.opencontainers.image.documentation="https://github.com/prometheus/collectd_exporter"
+LABEL org.opencontainers.image.licenses="Apache License 2.0"
+LABEL io.prometheus.image.variant="distroless"
+
+COPY .build/${OS}-${ARCH}/collectd_exporter /bin/collectd_exporter
+
+EXPOSE      9103
+ENTRYPOINT  [ "/bin/collectd_exporter" ]


### PR DESCRIPTION
The distroless image runs as nonroot (UID 65532) without a shell, reducing the attack surface compared to the busybox-based image.